### PR TITLE
title does not exist in ModelentityController

### DIFF
--- a/base_model/includes/ModelentityController.inc
+++ b/base_model/includes/ModelentityController.inc
@@ -34,7 +34,7 @@ class ModelentityController extends EntityAPIController {
       'modelentity_id' => '',
       'uid'            => $user->uid,
       'is_new'         => TRUE,
-      'title'          => '',
+      'name'          => '',
       'created'        => REQUEST_TIME,
       'changed'        => '',
     );


### PR DESCRIPTION
`title`does not exist in entity controller, entity has a property `name`, but not `title`.
So `title`should be replaced by `name`.